### PR TITLE
Add link to example and local instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 D3 code to plot a skew-T log-P diagram
+
+## Example
+
+See live at [http://rsobash.github.io/d3-skewt](http://rsobash.github.io/d3-skewt)
+
+## Run locally
+
+```
+$ git clone git@github.com:rsobash/d3-skewt.git
+$ cd d3-skewt
+$ python -m SimpleHTTPServer 8000
+$ open http://localhost:8000
+```


### PR DESCRIPTION
Was looking for link to see example live, saw it was already gh-pages so seemed natural to have a link in the README.
